### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/tse-wei-chen/hs-sql-agent/security/code-scanning/21](https://github.com/tse-wei-chen/hs-sql-agent/security/code-scanning/21)

Add an explicit workflow-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access.  
Best fix here: add at the root (after `name` and before `on`) with:

- `contents: read`

This preserves current functionality (checkout and tests still work) while preventing unintended write access if defaults are permissive or change later. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
